### PR TITLE
Rework and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 [Click here](https://chrome.google.com/webstore/detail/shared-library-downloader/jdlidamgkbjkdogfgelbkkmdaehmeglp)
 
+## Safari version
+
+[Safari extension by WarningImHack3r](https://github.com/WarningImHack3r/plex-shared-library-downloader-safari) (Requires a Mac with Xcode)
+
 ## Description
 
 This Chrome extension creates a download button on media pages within plex to enable non-media-owners to download files.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Shared Library Downloader for Plex
 
-# [Chrome Store Download](https://chrome.google.com/webstore/detail/shared-library-downloader/jdlidamgkbjkdogfgelbkkmdaehmeglp?hl=en)
+## Chrome Store Download
+
+[Click here](https://chrome.google.com/webstore/detail/shared-library-downloader/jdlidamgkbjkdogfgelbkkmdaehmeglp)
+
+## Description
 
 This Chrome extension creates a download button on media pages within plex to enable non-media-owners to download files.
 

--- a/src/js/content_script.js
+++ b/src/js/content_script.js
@@ -1,9 +1,8 @@
-"use strict";
-
-// inject download script
-var s = document.createElement('script');
-s.src = chrome.runtime.getURL('js/download_script.js');
-s.onload = function() {
+// Inject download script
+var s = document.createElement("script");
+s.src = chrome.runtime.getURL("js/download_script.js");
+s.onload = function () {
     this.remove();
 };
 (document.head || document.documentElement).appendChild(s);
+console.log("Download script injected.");

--- a/src/js/content_script.js
+++ b/src/js/content_script.js
@@ -1,5 +1,7 @@
+"use strict";
+
 // Inject download script
-var s = document.createElement("script");
+const s = document.createElement("script");
 s.src = chrome.runtime.getURL("js/download_script.js");
 s.onload = function () {
     this.remove();

--- a/src/js/download_script.js
+++ b/src/js/download_script.js
@@ -56,7 +56,7 @@ if (typeof plxDwnld === "undefined") {
             const partKeyNode = xml.evaluate("//Media/Part[1]/@key", xml, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
 
             if (partKeyNode.singleNodeValue) {
-                window.location.href = baseUri + partKeyNode.singleNodeValue.textContent + "?X-Plex-Token=" + localStorage.myPlexAccessToken;
+                window.location.href = baseUri + partKeyNode.singleNodeValue.textContent + "?download=1&X-Plex-Token=" + localStorage.myPlexAccessToken;
             } else {
                 alert("Cannot start media download.");
             }

--- a/src/js/download_script.js
+++ b/src/js/download_script.js
@@ -39,8 +39,8 @@ if (typeof plxDwnld === "undefined") {
                     baseUri = baseUriNode.singleNodeValue.textContent;
                     const metadataId = /key=%2Flibrary%2Fmetadata%2F(\d+)/.exec(window.location.href);
 
-                    if (metadataId) {
-                        getXml(baseUri + "/library/metadata/" + metadataId + "?download=1&X-Plex-Token=" + localStorage.myPlexAccessToken, getDownloadUrl);
+                    if (metadataId && metadataId.length == 2) {
+                        getXml(baseUri + "/library/metadata/" + metadataId[1] + "?download=1&X-Plex-Token=" + localStorage.myPlexAccessToken, getDownloadUrl);
                     } else {
                         alert("Error while getting media id.");
                     }
@@ -76,24 +76,47 @@ if (typeof plxDwnld === "undefined") {
 
 const injectFunction = () => {
     console.log("Injecting...");
+
+    // Create download arrow element
     const dl_button_span = document.createElement('span');
     dl_button_span.id = 'injected_download_button';
     dl_button_span.innerHTML = '<svg fill="hsla(0,0%,100%,.7)" style="width:23px" version="1.1" viewBox="0 0 1024 1024" xml:space="preserve" xmlns="http://www.w3.org/2000/svg"><polygon points="921.3 655.7 921.3 900.4 102.7 900.4 102.7 655.7 215.2 655.7 215.2 787.9 808.8 787.9 808.8 655.7"/><path d="m906.3 655.7v83.1 131.3 30.3l15-15h-21.9-59.7-87.8-107.6-117.8-118.5-110.9-93.8-67.4c-10.6 0-21.3-0.4-31.9 0h-1.3l15 15v-83.1-131.3-30.3l-15 15h98.7 13.8l-15-15v115.7 16.5c0 8.1 6.9 15 15 15h59.1 141.8 171.6 148.2c23.9 0 47.9 0.6 71.9 0h1c8.1 0 15-6.9 15-15v-115.7-16.5l-15 15h98.7 13.8c7.8 0 15.4-6.9 15-15s-6.6-15-15-15h-98.7-13.8c-8.1 0-15 6.9-15 15v115.7 16.5l15-15h-59.1-141.8-171.6-148.2-48.8c-7.7 0-15.4-0.4-23.1 0h-1l15 15v-115.7-16.5c0-8.1-6.9-15-15-15h-98.7-13.8c-8.1 0-15 6.9-15 15v83.1 131.3 30.3c0 8.1 6.9 15 15 15h21.9 59.7 87.8 107.6 117.8 118.5 110.9 93.8 67.4c10.6 0 21.3 0.2 31.9 0h1.3c8.1 0 15-6.9 15-15v-83.1-131.3-30.3c0-7.8-6.9-15.4-15-15-8.1 0.3-15 6.6-15 15z"/><polygon points="751.3 425.5 512 670.9 272.7 425.5 430 425.5 430 123.6 594 123.6 594 425.5"/><path d="m740.7 414.9c-7.9 8.1-15.9 16.3-23.8 24.4-19 19.5-38.1 39.1-57.1 58.6-23 23.6-46.1 47.3-69.1 70.9-19.9 20.4-39.9 40.9-59.8 61.3-9.6 9.9-20.1 19.4-29.1 29.8l-0.4 0.4h21.2c-7.9-8.1-15.9-16.3-23.8-24.4-19-19.5-38.1-39.1-57.1-58.6-23-23.6-46.1-47.3-69.1-70.9-19.9-20.4-39.8-40.9-59.8-61.3-9.6-9.9-18.9-20.5-29.1-29.8l-0.4-0.4c-3.5 8.5-7.1 17.1-10.6 25.6h137.7 19.5c8.1 0 15-6.9 15-15v-102.2-162.7-36.9l-15 15h144 20.1l-15-15v102.2 162.7 36.9c0 8.1 6.9 15 15 15h137.7 19.5c7.8 0 15.4-6.9 15-15s-6.6-15-15-15h-137.7-19.5l15 15v-102.2-162.7-36.9c0-8.1-6.9-15-15-15h-144-20.1c-8.1 0-15 6.9-15 15v102.2 162.7 36.9l15-15h-137.7-19.5c-13.1 0-19.6 16.3-10.6 25.6 7.9 8.1 15.9 16.3 23.8 24.4 19 19.5 38.1 39.1 57.1 58.6 23 23.6 46.1 47.3 69.1 70.9 19.9 20.4 39.8 40.9 59.8 61.3 9.7 9.9 19.1 20.3 29.1 29.8l0.4 0.4c5.6 5.7 15.6 5.8 21.2 0 7.9-8.1 15.9-16.3 23.8-24.4 19-19.5 38.1-39.1 57.1-58.6 23-23.6 46.1-47.3 69.1-70.9 19.9-20.4 39.9-40.9 59.8-61.3 9.7-9.9 19.7-19.6 29.1-29.8l0.4-0.4c5.7-5.8 5.8-15.4 0-21.2-5.7-5.7-15.5-5.9-21.2 0z"/></svg>';
     dl_button_span.style.cursor = 'pointer';
     dl_button_span.style.paddingLeft = '10px';
 
-    const title_line = document.querySelector('[class*="PrePlayLeftTitle"]');
-    if (title_line) {
-        title_line.firstElementChild.after(dl_button_span);
-        document.getElementById(dl_button_span.id).addEventListener("click", plxDwnld.init);
-        console.log("Injected!");
-    } else {
-        console.log("Failed to inject. Wrong page?");
-    }
+    // "Find the title" part
+    const recurseChildren = (node, observer) => {
+        if (node.nodeType == Node.ELEMENT_NODE) {
+            if ((node.getAttribute("class") || "").includes("PrePlayLeftTitle")) {
+                if (document.getElementById(dl_button_span.id) == null) { // avoids duplicating buttons because of async
+                    observer.disconnect();
+                    
+                    node.firstElementChild.after(dl_button_span);
+                    document.getElementById(dl_button_span.id).addEventListener("click", plxDwnld.init);
+                
+                    console.log("Injected!");
+                }
+            } else if (node.childNodes) {
+                [...node.childNodes].forEach((child) => recurseChildren(child, observer));
+            }
+        }
+    };
+
+    new MutationObserver((mutations, observer) => {
+        mutations.forEach((mutation) => {
+            if (!mutation.addedNodes) return;
+
+            // Doesn't work without recursivity, because MutationObserver doesn't check subtree of new nodes in addedNodes
+            // See https://stackoverflow.com/a/61315048/12070367
+            [...mutation.addedNodes].forEach((node) => recurseChildren(node, observer));
+        });
+    }).observe(document.body, {
+        childList: true,
+        attributes: true,
+        subtree: true
+    });
 }
 
-window.onhashchange = () => {
-    setTimeout(injectFunction, 1000);
-};
+window.onhashchange = () => injectFunction();
 
-setTimeout(injectFunction, 1500); // inject on first load too
+injectFunction(); // inject on first load too

--- a/src/js/download_script.js
+++ b/src/js/download_script.js
@@ -4,7 +4,7 @@
  * This project is licensed under the terms of the MIT license, see https://piplongrun.github.io/plxdwnld/LICENSE.txt
  *
  * @author      Pip Longrun <pip.longrun@protonmail.com>
- * @version     0.3
+ * @version     0.4
  * @see         https://piplongrun.github.io/plxdwnld/
  *
  */
@@ -15,22 +15,22 @@ if (typeof plxDwnld === "undefined") {
     window.plxDwnld = (function () {
 
         const self = {};
-        const clientIdRegex = new RegExp("server\/([a-f0-9]{40})\/");
-        const metadataIdRegex = new RegExp("key=%2Flibrary%2Fmetadata%2F(\\d+)");
+        const clientIdRegex = /server\/([a-f0-9]{40})\//;
+        const metadataIdRegex = /key=%2Flibrary%2Fmetadata%2F(\d+)/;
         const apiResourceUrl = "https://plex.tv/api/resources?includeHttps=1&X-Plex-Token={token}";
         const apiLibraryUrl = "{baseuri}/library/metadata/{id}?X-Plex-Token={token}";
         const downloadUrl = "{baseuri}{partkey}?X-Plex-Token={token}";
-        const accessTokenXpath = "//Device[@clientIdentifier='{clientid}']/@accessToken";
-        const baseUriXpath = "//Device[@clientIdentifier='{clientid}']/Connection[@local='0']/@uri";
+        const baseUriXpath = "//Device[@clientIdentifier='{clientid}']/Connection[@local='0' and not(@address='https')]/@uri";
         const partKeyXpath = "//Media/Part[1]/@key";
-        let accessToken = null;
         let baseUri = null;
 
         const getXml = function (url, callback) {
             const request = new XMLHttpRequest();
-            request.onreadystatechange = function () {
+            request.onload = () => {
                 if (request.readyState == 4 && request.status == 200) {
                     callback(request.responseXML);
+                } else {
+                    alert("Unsuccessful XML URL: " + url);
                 }
             };
             request.open("GET", url);
@@ -41,24 +41,22 @@ if (typeof plxDwnld === "undefined") {
             const clientId = clientIdRegex.exec(window.location.href);
 
             if (clientId && clientId.length == 2) {
-                const accessTokenNode = xml.evaluate(accessTokenXpath.replace('{clientid}', clientId[1]), xml, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
                 const baseUriNode = xml.evaluate(baseUriXpath.replace('{clientid}', clientId[1]), xml, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
 
-                if (accessTokenNode.singleNodeValue && baseUriNode.singleNodeValue) {
-                    accessToken = accessTokenNode.singleNodeValue.textContent;
+                if (baseUriNode.singleNodeValue) {
                     baseUri = baseUriNode.singleNodeValue.textContent;
                     const metadataId = metadataIdRegex.exec(window.location.href);
 
-                    if (metadataId && metadataId.length == 2) {
-                        getXml(apiLibraryUrl.replace('{baseuri}', baseUri).replace('{id}', metadataId[1]).replace('{token}', accessToken), getDownloadUrl);
+                    if (metadataId) {
+                        getXml(apiLibraryUrl.replace('{baseuri}', baseUri).replace('{id}', metadataId).replace('{token}', localStorage.myPlexAccessToken), getDownloadUrl);
                     } else {
-                        alert("You are currently not viewing a media item.");
+                        alert("Error while getting media id.");
                     }
                 } else {
                     alert("Cannot find a valid accessToken.");
                 }
             } else {
-                alert("You are currently not viewing a media item.");
+                alert("Error while getting client id.");
             }
         };
 
@@ -66,9 +64,13 @@ if (typeof plxDwnld === "undefined") {
             const partKeyNode = xml.evaluate(partKeyXpath, xml, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
 
             if (partKeyNode.singleNodeValue) {
-                window.location.href = downloadUrl.replace('{baseuri}', baseUri).replace('{partkey}', partKeyNode.singleNodeValue.textContent).replace('{token}', accessToken);
+                let finalUrl = downloadUrl.replace('{baseuri}', baseUri).replace('{partkey}', partKeyNode.singleNodeValue.textContent).replace('{token}', localStorage.myPlexAccessToken);
+                if (!finalUrl.includes("download=1")) {
+                    finalUrl += "&download=1";
+                }
+                window.location.href = finalUrl;
             } else {
-                alert("You are currently not viewing a media item.");
+                alert("Cannot start media download.");
             }
         };
 
@@ -84,18 +86,26 @@ if (typeof plxDwnld === "undefined") {
     })();
 }
 
-window.addEventListener("hashchange", function () {
-    setTimeout(function () {
-        console.log('INJECTING!');
-        let dl_button_span = document.createElement('span');
-        dl_button_span.id = 'injected_download_button';
-        dl_button_span.innerHTML = '<svg fill="hsla(0,0%,100%,.7)" style="width:23px" version="1.1" viewBox="0 0 1024 1024" xml:space="preserve" xmlns="http://www.w3.org/2000/svg"><polygon points="921.3 655.7 921.3 900.4 102.7 900.4 102.7 655.7 215.2 655.7 215.2 787.9 808.8 787.9 808.8 655.7"/><path d="m906.3 655.7v83.1 131.3 30.3l15-15h-21.9-59.7-87.8-107.6-117.8-118.5-110.9-93.8-67.4c-10.6 0-21.3-0.4-31.9 0h-1.3l15 15v-83.1-131.3-30.3l-15 15h98.7 13.8l-15-15v115.7 16.5c0 8.1 6.9 15 15 15h59.1 141.8 171.6 148.2c23.9 0 47.9 0.6 71.9 0h1c8.1 0 15-6.9 15-15v-115.7-16.5l-15 15h98.7 13.8c7.8 0 15.4-6.9 15-15s-6.6-15-15-15h-98.7-13.8c-8.1 0-15 6.9-15 15v115.7 16.5l15-15h-59.1-141.8-171.6-148.2-48.8c-7.7 0-15.4-0.4-23.1 0h-1l15 15v-115.7-16.5c0-8.1-6.9-15-15-15h-98.7-13.8c-8.1 0-15 6.9-15 15v83.1 131.3 30.3c0 8.1 6.9 15 15 15h21.9 59.7 87.8 107.6 117.8 118.5 110.9 93.8 67.4c10.6 0 21.3 0.2 31.9 0h1.3c8.1 0 15-6.9 15-15v-83.1-131.3-30.3c0-7.8-6.9-15.4-15-15-8.1 0.3-15 6.6-15 15z"/><polygon points="751.3 425.5 512 670.9 272.7 425.5 430 425.5 430 123.6 594 123.6 594 425.5"/><path d="m740.7 414.9c-7.9 8.1-15.9 16.3-23.8 24.4-19 19.5-38.1 39.1-57.1 58.6-23 23.6-46.1 47.3-69.1 70.9-19.9 20.4-39.9 40.9-59.8 61.3-9.6 9.9-20.1 19.4-29.1 29.8l-0.4 0.4h21.2c-7.9-8.1-15.9-16.3-23.8-24.4-19-19.5-38.1-39.1-57.1-58.6-23-23.6-46.1-47.3-69.1-70.9-19.9-20.4-39.8-40.9-59.8-61.3-9.6-9.9-18.9-20.5-29.1-29.8l-0.4-0.4c-3.5 8.5-7.1 17.1-10.6 25.6h137.7 19.5c8.1 0 15-6.9 15-15v-102.2-162.7-36.9l-15 15h144 20.1l-15-15v102.2 162.7 36.9c0 8.1 6.9 15 15 15h137.7 19.5c7.8 0 15.4-6.9 15-15s-6.6-15-15-15h-137.7-19.5l15 15v-102.2-162.7-36.9c0-8.1-6.9-15-15-15h-144-20.1c-8.1 0-15 6.9-15 15v102.2 162.7 36.9l15-15h-137.7-19.5c-13.1 0-19.6 16.3-10.6 25.6 7.9 8.1 15.9 16.3 23.8 24.4 19 19.5 38.1 39.1 57.1 58.6 23 23.6 46.1 47.3 69.1 70.9 19.9 20.4 39.8 40.9 59.8 61.3 9.7 9.9 19.1 20.3 29.1 29.8l0.4 0.4c5.6 5.7 15.6 5.8 21.2 0 7.9-8.1 15.9-16.3 23.8-24.4 19-19.5 38.1-39.1 57.1-58.6 23-23.6 46.1-47.3 69.1-70.9 19.9-20.4 39.9-40.9 59.8-61.3 9.7-9.9 19.7-19.6 29.1-29.8l0.4-0.4c5.7-5.8 5.8-15.4 0-21.2-5.7-5.7-15.5-5.9-21.2 0z"/></svg>';
-        dl_button_span.style.cursor = 'pointer';
-        dl_button_span.style.paddingLeft = '10px';
+const injectFunction = () => {
+    console.log("Injecting...");
+    const dl_button_span = document.createElement('span');
+    dl_button_span.id = 'injected_download_button';
+    dl_button_span.innerHTML = '<svg fill="hsla(0,0%,100%,.7)" style="width:23px" version="1.1" viewBox="0 0 1024 1024" xml:space="preserve" xmlns="http://www.w3.org/2000/svg"><polygon points="921.3 655.7 921.3 900.4 102.7 900.4 102.7 655.7 215.2 655.7 215.2 787.9 808.8 787.9 808.8 655.7"/><path d="m906.3 655.7v83.1 131.3 30.3l15-15h-21.9-59.7-87.8-107.6-117.8-118.5-110.9-93.8-67.4c-10.6 0-21.3-0.4-31.9 0h-1.3l15 15v-83.1-131.3-30.3l-15 15h98.7 13.8l-15-15v115.7 16.5c0 8.1 6.9 15 15 15h59.1 141.8 171.6 148.2c23.9 0 47.9 0.6 71.9 0h1c8.1 0 15-6.9 15-15v-115.7-16.5l-15 15h98.7 13.8c7.8 0 15.4-6.9 15-15s-6.6-15-15-15h-98.7-13.8c-8.1 0-15 6.9-15 15v115.7 16.5l15-15h-59.1-141.8-171.6-148.2-48.8c-7.7 0-15.4-0.4-23.1 0h-1l15 15v-115.7-16.5c0-8.1-6.9-15-15-15h-98.7-13.8c-8.1 0-15 6.9-15 15v83.1 131.3 30.3c0 8.1 6.9 15 15 15h21.9 59.7 87.8 107.6 117.8 118.5 110.9 93.8 67.4c10.6 0 21.3 0.2 31.9 0h1.3c8.1 0 15-6.9 15-15v-83.1-131.3-30.3c0-7.8-6.9-15.4-15-15-8.1 0.3-15 6.6-15 15z"/><polygon points="751.3 425.5 512 670.9 272.7 425.5 430 425.5 430 123.6 594 123.6 594 425.5"/><path d="m740.7 414.9c-7.9 8.1-15.9 16.3-23.8 24.4-19 19.5-38.1 39.1-57.1 58.6-23 23.6-46.1 47.3-69.1 70.9-19.9 20.4-39.9 40.9-59.8 61.3-9.6 9.9-20.1 19.4-29.1 29.8l-0.4 0.4h21.2c-7.9-8.1-15.9-16.3-23.8-24.4-19-19.5-38.1-39.1-57.1-58.6-23-23.6-46.1-47.3-69.1-70.9-19.9-20.4-39.8-40.9-59.8-61.3-9.6-9.9-18.9-20.5-29.1-29.8l-0.4-0.4c-3.5 8.5-7.1 17.1-10.6 25.6h137.7 19.5c8.1 0 15-6.9 15-15v-102.2-162.7-36.9l-15 15h144 20.1l-15-15v102.2 162.7 36.9c0 8.1 6.9 15 15 15h137.7 19.5c7.8 0 15.4-6.9 15-15s-6.6-15-15-15h-137.7-19.5l15 15v-102.2-162.7-36.9c0-8.1-6.9-15-15-15h-144-20.1c-8.1 0-15 6.9-15 15v102.2 162.7 36.9l15-15h-137.7-19.5c-13.1 0-19.6 16.3-10.6 25.6 7.9 8.1 15.9 16.3 23.8 24.4 19 19.5 38.1 39.1 57.1 58.6 23 23.6 46.1 47.3 69.1 70.9 19.9 20.4 39.8 40.9 59.8 61.3 9.7 9.9 19.1 20.3 29.1 29.8l0.4 0.4c5.6 5.7 15.6 5.8 21.2 0 7.9-8.1 15.9-16.3 23.8-24.4 19-19.5 38.1-39.1 57.1-58.6 23-23.6 46.1-47.3 69.1-70.9 19.9-20.4 39.9-40.9 59.8-61.3 9.7-9.9 19.7-19.6 29.1-29.8l0.4-0.4c5.7-5.8 5.8-15.4 0-21.2-5.7-5.7-15.5-5.9-21.2 0z"/></svg>';
+    dl_button_span.style.cursor = 'pointer';
+    dl_button_span.style.paddingLeft = '10px';
 
-        let title_line = document.querySelector('[class*="PrePlayLeftTitle"]').firstElementChild;
-        title_line.after(dl_button_span);
+    const title_line = document.querySelector('[class*="PrePlayLeftTitle"]');
+    if (title_line) {
+        title_line.firstElementChild.after(dl_button_span);
+        document.getElementById(dl_button_span.id).addEventListener("click", plxDwnld.init);
+        console.log("Injected!");
+    } else {
+        console.log("Failed to inject. Wrong page?");
+    }
+}
 
-        document.getElementById(dl_button_span.id).addEventListener('click', plxDwnld.init);
-    }, 500);
-}, false);
+window.onhashchange = () => {
+    setTimeout(injectFunction, 1000);
+};
+
+setTimeout(injectFunction, 2000); // inject on first load too

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,10 +1,10 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
     "name": "Shared Library Downloader for Plex",
     "short_name": "Plex Downloader",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Add a download button to the Plex Web interface",
-    "page_action": {
+    "action": {
         "default_title": "Downloader for Plex",
         "default_icon": {
             "8": "img/logo8.png",
@@ -30,15 +30,20 @@
         "256": "img/logo256.png",
         "512": "img/logo512.png"
     },
-    "content_scripts": [{
-        "matches": ["https://app.plex.tv/*", "https://plex.tv/*"],
-        "js": ["js/content_script.js"],
-        "run_at": "document_idle",
-        "all_frames": true
-    }],
-    "permissions": [
-        "https://app.plex.tv/",
-        "https://plex.tv/"
+    "content_scripts": [
+        {
+            "matches": [ "https://app.plex.tv/*" ],
+            "js": [ "js/content_script.js" ],
+            "run_at": "document_idle",
+            "all_frames": true
+        }
     ],
-    "web_accessible_resources": ["js/download_script.js"]
+    "permissions": [ "tabs" ],
+    "host_permissions": [ "https://app.plex.tv/" ],
+    "web_accessible_resources": [
+        {
+            "resources": [ "js/download_script.js" ],
+            "matches": [ "https://app.plex.tv/*" ]
+        }
+    ]
 }


### PR DESCRIPTION
- Fix README lint
- Update to `manifest.json` v3
- Remove useless `plex.tv` domain from manifest (_this should only be working on app.plex.tv shouldn't it?_)
- Fix little stuff on injector
- Fix download button not working (update regex declaration, fix xml load handling, add injection on first page load, add more relevant error alerts, fix code here and there)
- Move global variables to inline

Future improvement could be allowing bulk downloads for TV shows e.g.