### PR TITLE
remove download parameter from download url to fix 403 error

### DIFF
--- a/src/js/download_script.js
+++ b/src/js/download_script.js
@@ -18,7 +18,7 @@ if (typeof plxDwnld === "undefined") {
         const metadataIdRegex = /key=%2Flibrary%2Fmetadata%2F(\d+)/;
         const apiResourceUrl = "https://plex.tv/api/resources?includeHttps=1&X-Plex-Token={token}";
         const apiLibraryUrl = "{baseuri}/library/metadata/{id}?X-Plex-Token={token}";
-        const downloadUrl = "{baseuri}{partkey}?download=1&X-Plex-Token={token}";
+        const downloadUrl = "{baseuri}{partkey}?X-Plex-Token={token}";
         const accessTokenXpath = "//Device[@clientIdentifier='{clientid}']/@accessToken";
         const baseUriXpath = "//Device[@clientIdentifier='{clientid}']/Connection[@local='0' and not(@address='https')]/@uri";
         const partKeyXpath = "//Media/Part[1]/@key";

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Shared Library Downloader for Plex",
     "short_name": "Plex Downloader",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "description": "Add a download button to the Plex Web interface",
     "action": {
         "default_title": "Downloader for Plex",


### PR DESCRIPTION
As others have found out, it is not longer possible to download movies with the download parameter set to 1 if you're not an plex pass user with download permission or the owner of the library. Thats because of changes in handling the download permission. (see https://nikisoft.wordpress.com/2021/08/07/how-to-download-from-plex-server/ or https://forums.plex.tv/t/plex-media-server/30447/451)

In fact, this problem was fixed a while ago by resolving Issue #5 but download=1 came back with PR #6 because it has the disadvantage that downloads are not named correctly, just file.mkv / file.mp4 and so on. I think a misnamed download is better than no download at all until a better solution is found for this problem.
